### PR TITLE
Reproduce the compile error with Gradle 7.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,17 @@
 plugins {
     id 'groovy'
-    id 'java-gradle-plugin'
+//    id 'java-gradle-plugin'
 }
 
 repositories {
     google()
     mavenCentral()
+    maven { url = uri('https://repo.nokee.dev/release') }
 }
 
 dependencies {
     implementation ("com.android.tools.build:gradle:7.0.4")
     implementation("com.android.tools:common:30.0.4")
-    implementation gradleApi()
+    implementation("dev.gradleplugins:gradle-api:7.5.1")
+    implementation("org.codehaus.groovy:groovy:3.0.13")
 }


### PR DESCRIPTION
Instead of using `java-gradle-plugin` and `gradleApi()`, the build uses external dependencies. This allows to show that the change of behaviour comes from the upgrade of Groovy from version 3.0.10 to 3.0.13.